### PR TITLE
fix: remove npm cache and install step for repos without package.json

### DIFF
--- a/.github/workflows/claude-dev.yml
+++ b/.github/workflows/claude-dev.yml
@@ -144,10 +144,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Run Claude Code
         uses: anthropics/claude-code-action@8cfb50531602989156055238cb98cca2db5d6bfd # v1


### PR DESCRIPTION
## Summary
- Removes `cache: npm` from `setup-node` step — this fails when no `package-lock.json` exists
- Removes the `npm ci` install step — this repo has no Node.js dependencies to install
- The `claude-code-action` handles Claude Code installation itself

## Root Cause
Both dev agent runs (issues #2 and #3) failed at the `Setup Node.js` step with:
> Dependencies lock file is not found. Supported file patterns: package-lock.json, npm-shrinkwrap.json, yarn.lock

## Test plan
- [ ] Re-trigger dev agents on issues #2 and #3 after merging
- [ ] Verify `Setup Node.js` step passes
- [ ] Verify `Run Claude Code` step launches successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)